### PR TITLE
Add local environment sample file for API configuration

### DIFF
--- a/.env.local.sample
+++ b/.env.local.sample
@@ -1,0 +1,6 @@
+# Copy this file to .env.local (e.g. `cp .env.local.sample .env.local`) before running the Vite dev server.
+# Set VITE_API_BASE_URL to point to your backend API.
+# - For local development outside Docker: http://localhost:3000
+# - When using Docker networking:      http://api:3000
+
+VITE_API_BASE_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ api/.env.*
 .env
 .env.*
 !*.example
+!.env.local.sample
 .env.local
 .env.development.local
 .env.production.local


### PR DESCRIPTION
## Summary
- add a `.env.local.sample` file to guide configuring the Vite API base URL
- update `.gitignore` so the sample environment file is tracked

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e22a48d5d8833388ea3f360ccf8fde