### PR TITLE
feat: add typed api client with token refresh

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,50 +1,455 @@
-const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:3000";
+const rawBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '';
+const API_BASE_URL = rawBaseUrl.replace(/\/$/, '');
 
-export async function apiFetch<T>(
-  path: string,
-  options: RequestInit = {},
-  token?: string
-): Promise<T> {
-  const headers = new Headers(options.headers || {});
-  if (!headers.has("Content-Type")) headers.set("Content-Type", "application/json");
-  if (token) headers.set("Authorization", `Bearer ${token}`);
+const ACCESS_TOKEN_KEY = 'bitininkas_access_token';
+const REFRESH_TOKEN_KEY = 'bitininkas_refresh_token';
+const USER_STORAGE_KEY = 'bitininkas_user';
 
-  const res = await fetch(`${BASE_URL}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const text = await res.text().catch(() => "");
-    throw new Error(`API ${res.status}: ${text || res.statusText}`);
+export class HttpError<T = unknown> extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly data: T,
+    message?: string
+  ) {
+    super(message ?? `HTTP ${status}`);
+    this.name = 'HttpError';
   }
-  if (res.status === 204) return undefined as T; // no content
-  return (await res.json()) as T;
 }
 
-export const api = {
-  login: (email: string, password: string) =>
-    apiFetch<{ accessToken: string }>("/auth/login", {
-      method: "POST",
-      body: JSON.stringify({ email, password }),
-    }),
+type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE';
+type QueryValue = string | number | boolean | null | undefined;
 
-  me: (token: string) =>
-    apiFetch<{ id: string; email: string; role: string; name?: string }>("/auth/me", {}, token),
+export interface RequestOptions extends Omit<RequestInit, 'method' | 'body'> {
+  json?: unknown;
+  body?: BodyInit | null;
+  query?: Record<string, QueryValue>;
+  skipAuth?: boolean;
+}
 
-  // Pavyzdžiai – pririšk UI sąrašus/formas:
-  listHives: (token: string) =>
-    apiFetch<Array<{ id: string; label: string; status: string }>>("/hives", {}, token),
+interface InternalRequestOptions extends RequestOptions {
+  _retry?: boolean;
+}
 
-  createHive: (token: string, dto: { label: string; status?: string }) =>
-    apiFetch<{ id: string }>("/hives", { method: "POST", body: JSON.stringify(dto) }, token),
+export type UserRole = 'user' | 'manager' | 'admin';
 
-  updateHive: (token: string, id: string, dto: { label?: string; status?: string }) =>
-    apiFetch(`/hives/${id}`, { method: "PATCH", body: JSON.stringify(dto) }, token),
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  role: UserRole;
+  name?: string | null;
+}
 
-  deleteHive: (token: string, id: string) =>
-    apiFetch<void>(`/hives/${id}`, { method: "DELETE" }, token),
+export interface AuthResponse {
+  accessToken: string;
+  refreshToken: string;
+  user: AuthenticatedUser;
+}
 
-  notifications: (token: string) =>
-    apiFetch<Array<{ id: string; type: string; payload: any; createdAt: string }>>(
-      "/notifications",
-      {},
-      token
-    ),
+export interface NotificationResponse {
+  id: string;
+  userId: string;
+  type: string;
+  payload: Record<string, unknown>;
+  scheduledAt?: string | null;
+  sentAt?: string | null;
+  readAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type HiveStatus = 'active' | 'paused' | 'archived';
+
+export interface HiveResponse {
+  id: string;
+  label: string;
+  status: HiveStatus;
+  location?: string | null;
+  queenYear?: number | null;
+  ownerUserId?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface HiveSummary {
+  hiveId: string;
+  assignmentsCount: number;
+  completion: number;
+}
+
+export type TaskFrequency = 'once' | 'weekly' | 'monthly';
+
+export interface TaskStepResponse {
+  id: string;
+  taskId: string;
+  orderIndex: number;
+  title: string;
+  contentText?: string | null;
+  mediaUrl?: string | null;
+  createdAt: string;
+}
+
+export interface TaskResponse {
+  id: string;
+  title: string;
+  description?: string | null;
+  category?: string | null;
+  seasonMonths: number[];
+  frequency: TaskFrequency;
+  defaultDueDays: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TaskWithStepsResponse extends TaskResponse {
+  steps: TaskStepResponse[];
+}
+
+export type AssignmentStatus = 'not_started' | 'in_progress' | 'done';
+
+export interface AssignmentResponse {
+  id: string;
+  hiveId: string;
+  taskId: string;
+  createdByUserId: string;
+  dueDate: string;
+  status: AssignmentStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface StepProgressResponse {
+  id: string;
+  assignmentId: string;
+  taskStepId: string;
+  completedAt: string;
+  notes?: string | null;
+  evidenceUrl?: string | null;
+}
+
+export interface AssignmentDetails {
+  assignment: AssignmentResponse;
+  task: TaskWithStepsResponse;
+  progress: StepProgressResponse[];
+  completion: number;
+}
+
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+export interface RegisterPayload {
+  name: string;
+  email: string;
+  password: string;
+}
+
+export interface CreateHivePayload {
+  label: string;
+  location?: string;
+  queenYear?: number;
+  status?: HiveStatus;
+  ownerUserId?: string;
+}
+
+export type UpdateHivePayload = Partial<CreateHivePayload>;
+
+export interface CreateAssignmentPayload {
+  hiveId: string;
+  taskId: string;
+  dueDate: string;
+  status?: AssignmentStatus;
+}
+
+export interface UpdateAssignmentPayload {
+  status?: AssignmentStatus;
+  dueDate?: string;
+}
+
+export interface CompleteStepPayload {
+  assignmentId: string;
+  taskStepId: string;
+  notes?: string;
+  evidenceUrl?: string;
+}
+
+const isBrowser = typeof window !== 'undefined';
+
+let accessToken = isBrowser ? window.localStorage.getItem(ACCESS_TOKEN_KEY) : null;
+let refreshTokenValue = isBrowser ? window.localStorage.getItem(REFRESH_TOKEN_KEY) : null;
+let refreshPromise: Promise<boolean> | null = null;
+
+const buildUrl = (path: string, query?: Record<string, QueryValue>) => {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const base = API_BASE_URL;
+  let url = base ? `${base}${normalizedPath}` : normalizedPath;
+
+  if (query) {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === null) continue;
+      params.append(key, String(value));
+    }
+    const qs = params.toString();
+    if (qs) {
+      url += (url.includes('?') ? '&' : '?') + qs;
+    }
+  }
+
+  return url;
 };
+
+const safeParse = async (response: Response): Promise<unknown> => {
+  if (response.status === 204) return undefined;
+  const contentType = response.headers.get('content-type') ?? '';
+  const text = await response.text();
+  if (!text) return undefined;
+  if (contentType.includes('application/json')) {
+    try {
+      return JSON.parse(text);
+    } catch (error) {
+      console.warn('Failed to parse JSON response', error);
+    }
+  }
+  return text;
+};
+
+const persistUser = (user: AuthenticatedUser | undefined) => {
+  if (!isBrowser) return;
+  if (user) {
+    window.localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(user));
+  } else {
+    window.localStorage.removeItem(USER_STORAGE_KEY);
+  }
+};
+
+const setRefreshToken = (token: string | null) => {
+  refreshTokenValue = token ?? null;
+  if (!isBrowser) return;
+  if (token) {
+    window.localStorage.setItem(REFRESH_TOKEN_KEY, token);
+  } else {
+    window.localStorage.removeItem(REFRESH_TOKEN_KEY);
+  }
+};
+
+const getRefreshToken = () => {
+  if (refreshTokenValue) return refreshTokenValue;
+  if (isBrowser) {
+    refreshTokenValue = window.localStorage.getItem(REFRESH_TOKEN_KEY);
+  }
+  return refreshTokenValue;
+};
+
+export const setToken = (token: string | null, refresh?: string | null) => {
+  accessToken = token ?? null;
+  if (isBrowser) {
+    if (token) {
+      window.localStorage.setItem(ACCESS_TOKEN_KEY, token);
+    } else {
+      window.localStorage.removeItem(ACCESS_TOKEN_KEY);
+    }
+  }
+  if (refresh !== undefined) {
+    setRefreshToken(refresh);
+  } else if (token === null) {
+    setRefreshToken(null);
+  }
+};
+
+export const clearCredentials = () => {
+  setToken(null, null);
+  persistUser(undefined);
+};
+
+const redirectToLogin = () => {
+  if (!isBrowser) return;
+  if (window.location.pathname === '/auth/login') return;
+  window.location.href = '/auth/login';
+};
+
+const attemptTokenRefresh = async () => {
+  const token = getRefreshToken();
+  if (!token) return false;
+
+  if (!refreshPromise) {
+    refreshPromise = (async () => {
+      try {
+        const response = await fetch(buildUrl('/auth/refresh'), {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ refreshToken: token }),
+        });
+
+        if (!response.ok) {
+          return false;
+        }
+
+        const data = (await safeParse(response)) as AuthResponse | undefined;
+        if (!data) {
+          return false;
+        }
+
+        setToken(data.accessToken, data.refreshToken);
+        persistUser(data.user);
+        return true;
+      } catch (error) {
+        console.error('Failed to refresh token', error);
+        return false;
+      } finally {
+        refreshPromise = null;
+      }
+    })();
+  }
+
+  return refreshPromise;
+};
+
+const request = async <T>(
+  method: HttpMethod,
+  path: string,
+  options: InternalRequestOptions = {}
+): Promise<T> => {
+  const { json, body, query, skipAuth = false, headers, _retry, ...rest } = options;
+  const url = buildUrl(path, query);
+  const finalHeaders = new Headers(headers);
+
+  if (!finalHeaders.has('Accept')) {
+    finalHeaders.set('Accept', 'application/json');
+  }
+
+  let requestBody = body ?? null;
+  if (json !== undefined) {
+    requestBody = JSON.stringify(json);
+    if (!finalHeaders.has('Content-Type')) {
+      finalHeaders.set('Content-Type', 'application/json');
+    }
+  }
+
+  if (!skipAuth && accessToken && !finalHeaders.has('Authorization')) {
+    finalHeaders.set('Authorization', `Bearer ${accessToken}`);
+  }
+
+  const response = await fetch(url, {
+    ...rest,
+    method,
+    headers: finalHeaders,
+    body: requestBody,
+  });
+
+  if (response.status === 401 && !skipAuth) {
+    const refreshed = !_retry ? await attemptTokenRefresh() : false;
+    if (refreshed) {
+      return request<T>(method, path, { ...options, _retry: true });
+    }
+    clearCredentials();
+    redirectToLogin();
+    const errorData = await safeParse(response);
+    throw new HttpError(response.status, errorData, 'Unauthorized');
+  }
+
+  const data = await safeParse(response);
+  if (!response.ok) {
+    throw new HttpError(response.status, data, response.statusText);
+  }
+
+  return data as T;
+};
+
+export const get = <T>(path: string, options?: RequestOptions) =>
+  request<T>('GET', path, options);
+
+export const post = <T>(path: string, options?: RequestOptions) =>
+  request<T>('POST', path, options);
+
+export const patch = <T>(path: string, options?: RequestOptions) =>
+  request<T>('PATCH', path, options);
+
+export const del = <T>(path: string, options?: RequestOptions) =>
+  request<T>('DELETE', path, options);
+
+export const api = {
+  auth: {
+    login: async (payload: LoginPayload) => {
+      const result = await post<AuthResponse>('/auth/login', {
+        json: payload,
+        skipAuth: true,
+      });
+      setToken(result.accessToken, result.refreshToken);
+      persistUser(result.user);
+      return result;
+    },
+    register: async (payload: RegisterPayload) => {
+      const result = await post<AuthResponse>('/auth/register', {
+        json: payload,
+        skipAuth: true,
+      });
+      setToken(result.accessToken, result.refreshToken);
+      persistUser(result.user);
+      return result;
+    },
+    refresh: async (refreshToken: string) => {
+      const result = await post<AuthResponse>('/auth/refresh', {
+        json: { refreshToken },
+        skipAuth: true,
+      });
+      setToken(result.accessToken, result.refreshToken);
+      persistUser(result.user);
+      return result;
+    },
+    me: () => get<AuthenticatedUser>('/auth/me'),
+    requestPasswordReset: (email: string) =>
+      post<{ message: string }>('/auth/request-reset', {
+        json: { email },
+        skipAuth: true,
+      }),
+    logout: () => {
+      clearCredentials();
+    },
+  },
+  notifications: {
+    list: () => get<NotificationResponse[]>('/notifications'),
+    markRead: (id: string) => patch<NotificationResponse>(`/notifications/${id}/read`),
+  },
+  hives: {
+    list: (params?: { status?: HiveStatus }) => get<HiveResponse[]>('/hives', { query: params }),
+    details: (id: string) => get<HiveResponse>(`/hives/${id}`),
+    create: (payload: CreateHivePayload) => post<HiveResponse>('/hives', { json: payload }),
+    update: (id: string, payload: UpdateHivePayload) =>
+      patch<HiveResponse>(`/hives/${id}`, { json: payload }),
+    remove: (id: string) => del<void>(`/hives/${id}`),
+    summary: (id: string) => get<HiveSummary>(`/hives/${id}/summary`),
+  },
+  tasks: {
+    list: (params?: { category?: string; frequency?: TaskFrequency; seasonMonth?: number }) =>
+      get<TaskResponse[]>('/tasks', { query: params }),
+    get: (id: string) => get<TaskResponse>(`/tasks/${id}`),
+    getSteps: (id: string) => get<TaskStepResponse[]>(`/tasks/${id}/steps`),
+    create: (payload: Partial<TaskWithStepsResponse>) => post<TaskResponse>('/tasks', { json: payload }),
+    update: (id: string, payload: Partial<TaskWithStepsResponse>) =>
+      patch<TaskResponse>(`/tasks/${id}`, { json: payload }),
+    reorderSteps: (id: string, payload: { stepIds: string[] }) =>
+      post<TaskStepResponse[]>(`/tasks/${id}/steps/reorder`, { json: payload }),
+  },
+  assignments: {
+    list: (params?: { hiveId?: string }) => get<AssignmentResponse[]>('/assignments', { query: params }),
+    create: (payload: CreateAssignmentPayload) => post<AssignmentResponse>('/assignments', { json: payload }),
+    update: (id: string, payload: UpdateAssignmentPayload) =>
+      patch<AssignmentResponse>(`/assignments/${id}`, { json: payload }),
+    details: (id: string) => get<AssignmentDetails>(`/assignments/${id}/details`),
+  },
+  progress: {
+    completeStep: (payload: CompleteStepPayload) =>
+      post<StepProgressResponse>('/progress/step-complete', { json: payload }),
+    listForAssignment: (assignmentId: string) =>
+      get<StepProgressResponse[]>(`/assignments/${assignmentId}/progress/list`),
+    assignmentCompletion: (assignmentId: string) =>
+      get<number>(`/assignments/${assignmentId}/progress`),
+    remove: (id: string) => del<void>(`/progress/${id}`),
+  },
+};
+
+export default api;


### PR DESCRIPTION
## Summary
- replace the legacy API helper with a typed client configured from `VITE_API_BASE_URL`
- add token management utilities that automatically refresh on 401s and persist credentials
- expose typed domain helpers for auth, notifications, hives, tasks, assignments, and progress endpoints

## Testing
- npm run lint *(fails: existing lint errors in backend/UI files outside the changes)*

------
https://chatgpt.com/codex/tasks/task_e_68e22c62df5c8333863b56201d1a4024