### PR TITLE
Switch tasks views to assignments API

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import ForgotPassword from "./pages/auth/ForgotPassword";
 import Hives from "./pages/Hives";
 import HiveDetail from "./pages/HiveDetail";
 import Tasks from "./pages/Tasks";
+import TaskDetail from "./pages/TaskDetail";
 import TaskRun from "./pages/TaskRun";
 import Notifications from "./pages/Notifications";
 import Profile from "./pages/Profile";
@@ -38,6 +39,7 @@ const App = () => (
             <Route path="/hives" element={<Hives />} />
             <Route path="/hives/:id" element={<HiveDetail />} />
             <Route path="/tasks" element={<Tasks />} />
+            <Route path="/tasks/:id" element={<TaskDetail />} />
             <Route path="/tasks/:id/run" element={<TaskRun />} />
             <Route path="/notifications" element={<Notifications />} />
             <Route path="/profile" element={<Profile />} />

--- a/src/components/AssignmentStatusBadge.tsx
+++ b/src/components/AssignmentStatusBadge.tsx
@@ -1,0 +1,34 @@
+import { Badge } from '@/components/ui/badge';
+import type { BadgeProps } from '@/components/ui/badge';
+import type { AssignmentStatus } from '@/lib/api';
+import {
+  type AssignmentUiStatus,
+  assignmentStatusLabels,
+  resolveAssignmentUiStatus,
+} from '@/lib/assignmentStatus';
+import { cn } from '@/lib/utils';
+
+const badgeVariantsByStatus: Record<AssignmentUiStatus, BadgeProps['variant']> = {
+  not_started: 'secondary',
+  in_progress: 'default',
+  done: 'success',
+  overdue: 'destructive',
+};
+
+interface AssignmentStatusBadgeProps {
+  status: AssignmentStatus;
+  dueDate?: string | null;
+  className?: string;
+}
+
+export function AssignmentStatusBadge({ status, dueDate, className }: AssignmentStatusBadgeProps) {
+  const uiStatus = resolveAssignmentUiStatus(status, dueDate);
+  const variant = badgeVariantsByStatus[uiStatus];
+
+  return (
+    <Badge variant={variant} className={cn(className)}>
+      {assignmentStatusLabels[uiStatus]}
+    </Badge>
+  );
+}
+

--- a/src/lib/assignmentStatus.ts
+++ b/src/lib/assignmentStatus.ts
@@ -1,0 +1,38 @@
+import type { AssignmentStatus } from '@/lib/api';
+
+export type AssignmentUiStatus = AssignmentStatus | 'overdue';
+
+export const assignmentStatusLabels: Record<AssignmentUiStatus, string> = {
+  not_started: 'Laukiama',
+  in_progress: 'Vykdoma',
+  done: 'Atlikta',
+  overdue: 'Vėluojama',
+};
+
+export const resolveAssignmentUiStatus = (status: AssignmentStatus, dueDate?: string | null): AssignmentUiStatus => {
+  if (status === 'done') {
+    return status;
+  }
+
+  if (!dueDate) {
+    return status;
+  }
+
+  const due = new Date(dueDate);
+  const now = new Date();
+
+  if (!Number.isNaN(due.getTime()) && due < now) {
+    return 'overdue';
+  }
+
+  return status;
+};
+
+export const assignmentStatusFilterOptions: { value: AssignmentStatus | 'all' | 'overdue'; label: string }[] = [
+  { value: 'all', label: 'Visos būsenos' },
+  { value: 'not_started', label: assignmentStatusLabels.not_started },
+  { value: 'in_progress', label: assignmentStatusLabels.in_progress },
+  { value: 'done', label: assignmentStatusLabels.done },
+  { value: 'overdue', label: assignmentStatusLabels.overdue },
+];
+

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -1,0 +1,164 @@
+import { useMemo } from 'react';
+import { useNavigate, useParams, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { MainLayout } from '@/components/Layout/MainLayout';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { AssignmentStatusBadge } from '@/components/AssignmentStatusBadge';
+import api from '@/lib/api';
+import { Calendar, ChevronLeft, ClipboardList, Loader2 } from 'lucide-react';
+
+const formatDate = (dateStr?: string | null) => {
+  if (!dateStr) return '—';
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleDateString('lt-LT', { year: 'numeric', month: 'long', day: 'numeric' });
+};
+
+export default function TaskDetail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['assignments', id, 'details'],
+    queryFn: () => api.assignments.details(id ?? ''),
+    enabled: Boolean(id),
+  });
+
+  const steps = useMemo(() => {
+    if (!data) return [];
+    return [...data.task.steps].sort((a, b) => a.orderIndex - b.orderIndex);
+  }, [data]);
+
+  if (!id) {
+    return (
+      <MainLayout>
+        <Card className="shadow-custom">
+          <CardContent className="p-12 text-center text-muted-foreground">
+            Užduoties ID nerastas.
+          </CardContent>
+        </Card>
+      </MainLayout>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <MainLayout>
+        <div className="space-y-6">
+          <Button variant="ghost" onClick={() => navigate(-1)} className="pl-0">
+            <ChevronLeft className="mr-2 h-4 w-4" /> Grįžti
+          </Button>
+          <Card className="shadow-custom">
+            <CardContent className="p-6 space-y-4">
+              <Skeleton className="h-8 w-1/2" />
+              <Skeleton className="h-4 w-1/3" />
+              <Skeleton className="h-24 w-full" />
+            </CardContent>
+          </Card>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <MainLayout>
+        <div className="space-y-6">
+          <Button variant="ghost" onClick={() => navigate(-1)} className="pl-0">
+            <ChevronLeft className="mr-2 h-4 w-4" /> Grįžti
+          </Button>
+          <Card className="shadow-custom">
+            <CardContent className="p-12 text-center">
+              <Loader2 className="mx-auto mb-4 h-10 w-10 animate-spin text-muted-foreground" />
+              <p className="text-muted-foreground">{error instanceof Error ? error.message : 'Nepavyko įkelti užduoties.'}</p>
+            </CardContent>
+          </Card>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  const { assignment, task, completion } = data;
+  const completedStepIds = new Set(data.progress.map((item) => item.taskStepId));
+
+  return (
+    <MainLayout>
+      <div className="space-y-6">
+        <Button variant="ghost" onClick={() => navigate(-1)} className="pl-0 w-fit">
+          <ChevronLeft className="mr-2 h-4 w-4" /> Grįžti
+        </Button>
+
+        <Card className="shadow-custom">
+          <CardHeader>
+            <div className="flex items-start justify-between gap-4">
+              <div className="space-y-1">
+                <CardTitle className="text-2xl">{task.title}</CardTitle>
+                <p className="text-muted-foreground">Avilio užduotis</p>
+              </div>
+              <AssignmentStatusBadge status={assignment.status} dueDate={assignment.dueDate} />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <Calendar className="h-4 w-4" />
+                Terminas: <span className="text-foreground">{formatDate(assignment.dueDate)}</span>
+              </div>
+              <Badge variant="outline">Progresas: {completion}%</Badge>
+            </div>
+
+            {task.description ? (
+              <div className="space-y-2">
+                <h3 className="text-lg font-semibold">Aprašymas</h3>
+                <p className="text-muted-foreground leading-relaxed">{task.description}</p>
+              </div>
+            ) : null}
+
+            <div className="space-y-3">
+              <div className="flex items-center gap-2">
+                <ClipboardList className="h-5 w-5 text-muted-foreground" />
+                <h3 className="text-lg font-semibold">Žingsniai</h3>
+              </div>
+              <div className="space-y-2">
+                {steps.map((step, index) => {
+                  const isCompleted = completedStepIds.has(step.id);
+                  return (
+                    <div
+                      key={step.id}
+                      className="rounded-lg border border-border px-4 py-3 flex items-start justify-between gap-4"
+                    >
+                      <div>
+                        <p className="text-sm font-medium text-foreground">
+                          {index + 1}. {step.title}
+                        </p>
+                        {step.contentText ? (
+                          <p className="mt-1 text-sm text-muted-foreground leading-relaxed">{step.contentText}</p>
+                        ) : null}
+                      </div>
+                      {isCompleted ? <Badge variant="success">Atlikta</Badge> : <Badge variant="outline">Neatlikta</Badge>}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-3">
+              <Button asChild>
+                <Link to={`/tasks/${assignment.id}/run`}>Vykdyti užduotį</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </MainLayout>
+  );
+}
+

--- a/src/pages/TaskRun.tsx
+++ b/src/pages/TaskRun.tsx
@@ -1,32 +1,178 @@
-import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { MainLayout } from '@/components/Layout/MainLayout';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
-import { Checkbox } from '@/components/ui/checkbox';
-import { mockAssignments } from '@/lib/mockData';
-import { ChevronLeft, ChevronRight, CheckCircle2, Upload, Image } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { AssignmentStatusBadge } from '@/components/AssignmentStatusBadge';
+import api, { type AssignmentStatus, type HttpError, type StepProgressResponse } from '@/lib/api';
+import { Calendar, CheckCircle2, ChevronLeft, ChevronRight } from 'lucide-react';
 import { toast } from 'sonner';
 
-export default function TaskRun() {
-  const { id } = useParams();
-  const navigate = useNavigate();
-  const assignment = mockAssignments.find(a => a.id === id);
+const formatDate = (value?: string | null) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleDateString('lt-LT', { year: 'numeric', month: 'long', day: 'numeric' });
+};
 
+const getErrorMessage = (error: unknown) => {
+  if (!error) return 'Įvyko nenumatyta klaida';
+  if (error instanceof Error) return error.message;
+  return 'Įvyko nenumatyta klaida';
+};
+
+export default function TaskRun() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
-  const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
   const [notes, setNotes] = useState('');
 
-  if (!assignment) {
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['assignments', id, 'details'],
+    queryFn: () => api.assignments.details(id ?? ''),
+    enabled: Boolean(id),
+  });
+
+  const steps = useMemo(() => {
+    if (!data) return [];
+    return [...data.task.steps].sort((a, b) => a.orderIndex - b.orderIndex);
+  }, [data]);
+
+  const completedStepIds = useMemo(() => {
+    if (!data) return new Set<string>();
+    return new Set(data.progress.map((item) => item.taskStepId));
+  }, [data]);
+
+  const currentStep = steps[currentStepIndex];
+  const assignment = data?.assignment;
+  const hiveId = assignment?.hiveId;
+
+  const { data: hive } = useQuery({
+    queryKey: ['hives', hiveId],
+    queryFn: () => api.hives.details(hiveId ?? ''),
+    enabled: Boolean(hiveId),
+  });
+
+  const updateAssignmentStatusMutation = useMutation({
+    mutationFn: (status: AssignmentStatus) => api.assignments.update(id!, { status }),
+    onSuccess: (updatedAssignment) => {
+      queryClient.setQueryData(['assignments', id, 'details'], (oldData) => {
+        if (!oldData) return oldData;
+        return { ...oldData, assignment: updatedAssignment };
+      });
+      queryClient.invalidateQueries({ queryKey: ['assignments', 'list'] });
+    },
+    onError: (mutationError: HttpError | Error) => {
+      toast.error('Nepavyko atnaujinti užduoties būsenos', {
+        description: getErrorMessage(mutationError),
+      });
+    },
+  });
+
+  const completeStepMutation = useMutation({
+    mutationFn: (payload: { taskStepId: string; notes?: string }) =>
+      api.progress.completeStep({ assignmentId: id!, taskStepId: payload.taskStepId, notes: payload.notes }),
+    onSuccess: (progressEntry) => {
+      let previousStatus: AssignmentStatus | undefined;
+      let newCompletion = data?.completion ?? 0;
+      let added = false;
+
+      queryClient.setQueryData(['assignments', id, 'details'], (oldData) => {
+        if (!oldData) return oldData;
+        previousStatus = oldData.assignment.status;
+        if (oldData.progress.some((item) => item.taskStepId === progressEntry.taskStepId)) {
+          newCompletion = oldData.completion;
+          return oldData;
+        }
+
+        added = true;
+        const updatedProgress: StepProgressResponse[] = [...oldData.progress, progressEntry];
+        const totalSteps = oldData.task.steps.length;
+        newCompletion = totalSteps ? Math.round((updatedProgress.length / totalSteps) * 100) : 0;
+
+        return {
+          ...oldData,
+          progress: updatedProgress,
+          completion: newCompletion,
+        };
+      });
+
+      queryClient.invalidateQueries({ queryKey: ['assignments', 'list'] });
+
+      if (added) {
+        toast.success('Žingsnis pažymėtas kaip atliktas');
+
+        if (previousStatus === 'not_started' && newCompletion < 100) {
+          updateAssignmentStatusMutation.mutate('in_progress');
+        }
+
+        if (newCompletion === 100) {
+          updateAssignmentStatusMutation.mutate('done');
+          toast.success('Užduotis užbaigta!');
+          setTimeout(() => navigate('/tasks'), 1500);
+        } else if (currentStepIndex < steps.length - 1) {
+          setCurrentStepIndex((index) => index + 1);
+        }
+      }
+
+      setNotes('');
+    },
+    onError: (stepError: HttpError | Error) => {
+      toast.error('Nepavyko pažymėti žingsnio', {
+        description: getErrorMessage(stepError),
+      });
+    },
+  });
+
+  if (!id) {
+    return (
+      <MainLayout>
+        <Card className="shadow-custom">
+          <CardContent className="p-12 text-center text-muted-foreground">
+            Užduoties ID nerastas.
+          </CardContent>
+        </Card>
+      </MainLayout>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <MainLayout>
+        <div className="space-y-6">
+          <Button variant="ghost" onClick={() => navigate(-1)} className="pl-0">
+            <ChevronLeft className="mr-2 h-4 w-4" /> Grįžti
+          </Button>
+          <Card className="shadow-custom">
+            <CardContent className="space-y-6 p-6">
+              <Skeleton className="h-8 w-2/3" />
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-48 w-full" />
+            </CardContent>
+          </Card>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  if (isError || !data || !assignment) {
     return (
       <MainLayout>
         <Card className="shadow-custom">
           <CardContent className="p-12 text-center">
             <h3 className="text-lg font-semibold mb-2">Užduotis nerasta</h3>
-            <p className="text-muted-foreground mb-6">Užduotis su šiuo ID neegzistuoja</p>
+            <p className="text-muted-foreground mb-6">{getErrorMessage(error)}</p>
             <Button onClick={() => navigate('/tasks')}>Grįžti į užduotis</Button>
           </CardContent>
         </Card>
@@ -34,48 +180,36 @@ export default function TaskRun() {
     );
   }
 
-  const steps = assignment.task.steps;
-  const currentStep = steps[currentStepIndex];
-  const progress = Math.round((completedSteps.size / steps.length) * 100);
-
-  const handleStepComplete = () => {
-    const newCompleted = new Set(completedSteps);
-    newCompleted.add(currentStepIndex);
-    setCompletedSteps(newCompleted);
-    
-    // TODO: call POST /progress/step-complete
-    toast.success('Žingsnis pažymėtas kaip atliktas');
-
-    if (currentStepIndex < steps.length - 1) {
-      setCurrentStepIndex(currentStepIndex + 1);
-      setNotes('');
-    } else {
-      toast.success('Užduotis užbaigta!');
-      setTimeout(() => navigate('/tasks'), 1500);
-    }
-  };
+  const progressPercent = data.completion ?? 0;
+  const hasCurrentStepCompleted = currentStep ? completedStepIds.has(currentStep.id) : false;
 
   const handlePrevStep = () => {
-    if (currentStepIndex > 0) {
-      setCurrentStepIndex(currentStepIndex - 1);
-    }
+    setCurrentStepIndex((index) => Math.max(0, index - 1));
   };
 
   const handleNextStep = () => {
-    if (currentStepIndex < steps.length - 1) {
-      setCurrentStepIndex(currentStepIndex + 1);
-    }
+    setCurrentStepIndex((index) => Math.min(steps.length - 1, index + 1));
+  };
+
+  const handleStepComplete = () => {
+    if (!currentStep || completeStepMutation.isPending) return;
+    completeStepMutation.mutate({ taskStepId: currentStep.id, notes: notes || undefined });
   };
 
   return (
     <MainLayout>
       <div className="space-y-6">
         {/* Header */}
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold">{assignment.task.name}</h1>
-          <p className="text-muted-foreground">
-            Avilys: {assignment.hive.name} | Progresas: {progress}%
-          </p>
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <h1 className="text-3xl font-bold">{data.task.title}</h1>
+            <p className="text-muted-foreground mt-1 flex items-center gap-3 text-sm md:text-base">
+              <span>Avilys: {hive?.label ?? assignment.hiveId}</span>
+              <span className="hidden md:inline">•</span>
+              <span>Terminas: {formatDate(assignment.dueDate)}</span>
+            </p>
+          </div>
+          <AssignmentStatusBadge status={assignment.status} dueDate={assignment.dueDate} />
         </div>
 
         {/* Progress Bar */}
@@ -84,141 +218,111 @@ export default function TaskRun() {
             <div className="space-y-2">
               <div className="flex items-center justify-between text-sm">
                 <span className="text-muted-foreground">Bendras progresas</span>
-                <span className="font-semibold">{progress}%</span>
+                <span className="font-semibold">{progressPercent}%</span>
               </div>
-              <Progress value={progress} className="h-3" />
+              <Progress value={progressPercent} className="h-3" />
             </div>
           </CardContent>
         </Card>
 
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
           {/* Steps Sidebar */}
-          <Card className="lg:col-span-1 shadow-custom h-fit">
+          <Card className="shadow-custom h-fit lg:col-span-1">
             <CardHeader>
               <CardTitle className="text-lg">Žingsniai</CardTitle>
             </CardHeader>
             <CardContent className="space-y-2">
-              {steps.map((step, index) => (
-                <button
-                  key={step.id}
-                  onClick={() => setCurrentStepIndex(index)}
-                  className={`w-full text-left p-3 rounded-lg transition-colors ${
-                    index === currentStepIndex
-                      ? 'bg-primary text-primary-foreground'
-                      : completedSteps.has(index)
-                      ? 'bg-success/10 text-success'
-                      : 'bg-muted hover:bg-muted/80'
-                  }`}
-                >
-                  <div className="flex items-center gap-2">
-                    {completedSteps.has(index) ? (
-                      <CheckCircle2 className="w-4 h-4 flex-shrink-0" />
-                    ) : (
-                      <div className="w-5 h-5 rounded-full border-2 flex-shrink-0 flex items-center justify-center text-xs">
-                        {index + 1}
-                      </div>
-                    )}
-                    <span className="text-sm font-medium line-clamp-2">{step.title}</span>
-                  </div>
-                </button>
-              ))}
+              {steps.map((step, index) => {
+                const isCompleted = completedStepIds.has(step.id);
+                const isActive = index === currentStepIndex;
+
+                return (
+                  <button
+                    key={step.id}
+                    onClick={() => setCurrentStepIndex(index)}
+                    className={`w-full rounded-lg p-3 text-left transition-colors ${
+                      isActive
+                        ? 'bg-primary text-primary-foreground'
+                        : isCompleted
+                        ? 'bg-success/10 text-success'
+                        : 'bg-muted hover:bg-muted/80'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      {isCompleted ? (
+                        <CheckCircle2 className="h-4 w-4 flex-shrink-0" />
+                      ) : (
+                        <div className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border-2 text-xs">
+                          {index + 1}
+                        </div>
+                      )}
+                      <span className="text-sm font-medium line-clamp-2">{step.title}</span>
+                    </div>
+                  </button>
+                );
+              })}
             </CardContent>
           </Card>
 
           {/* Main Content */}
-          <div className="lg:col-span-3 space-y-6">
-            {/* Current Step */}
+          <div className="space-y-6 lg:col-span-3">
             <Card className="shadow-custom">
               <CardHeader>
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
-                    <p className="text-sm text-muted-foreground mb-1">
+                    <p className="mb-1 text-sm text-muted-foreground">
                       Žingsnis {currentStepIndex + 1} iš {steps.length}
                     </p>
-                    <CardTitle className="text-2xl">{currentStep.title}</CardTitle>
+                    <CardTitle className="text-2xl">{currentStep?.title ?? 'Žingsnis nerastas'}</CardTitle>
                   </div>
-                  {completedSteps.has(currentStepIndex) && (
-                    <CheckCircle2 className="w-6 h-6 text-success" />
-                  )}
+                  {hasCurrentStepCompleted ? <CheckCircle2 className="h-6 w-6 text-success" /> : null}
                 </div>
               </CardHeader>
               <CardContent className="space-y-6">
                 <div>
-                  <h4 className="font-semibold mb-2">Aprašymas</h4>
-                  <p className="text-muted-foreground">{currentStep.description}</p>
+                  <h4 className="mb-2 font-semibold">Instrukcijos</h4>
+                  <p className="text-foreground">
+                    {currentStep?.contentText ?? 'Šio žingsnio instrukcijos nepateiktos.'}
+                  </p>
                 </div>
 
-                <div>
-                  <h4 className="font-semibold mb-2">Instrukcijos</h4>
-                  <p className="text-foreground">{currentStep.contentText}</p>
-                </div>
-
-                {currentStep.requiresProof && (
-                  <div className="rounded-lg bg-warning/10 border border-warning/20 p-4">
-                    <div className="flex items-start gap-2">
-                      <Image className="w-5 h-5 text-warning mt-0.5" />
-                      <div>
-                        <p className="font-medium text-warning-foreground">Reikalingas įrodymas</p>
-                        <p className="text-sm text-muted-foreground mt-1">
-                          Šiam žingsniui reikalinga nuotrauka ar įrašas
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-                )}
-
-                {/* Media Upload Stub */}
-                {currentStep.requiresProof && (
-                  <div className="space-y-2">
-                    <Label>Įkelti {currentStep.mediaType === 'image' ? 'nuotrauką' : 'failą'}</Label>
-                    <div className="border-2 border-dashed border-border rounded-lg p-8 text-center hover:border-primary/50 transition-colors cursor-pointer">
-                      <Upload className="w-8 h-8 mx-auto mb-2 text-muted-foreground" />
-                      <p className="text-sm text-muted-foreground">
-                        Spustelėkite arba nutempkite failą čia
-                      </p>
-                    </div>
-                  </div>
-                )}
-
-                {/* Notes */}
                 <div className="space-y-2">
                   <Label htmlFor="notes">Pastabos (nebūtina)</Label>
                   <Textarea
                     id="notes"
                     placeholder="Įveskite savo pastabas..."
                     value={notes}
-                    onChange={(e) => setNotes(e.target.value)}
+                    onChange={(event) => setNotes(event.target.value)}
                     rows={4}
                   />
+                </div>
+
+                <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                  <Calendar className="h-4 w-4" />
+                  <span>Žingsnis sukurtas: {currentStep ? formatDate(currentStep.createdAt) : '—'}</span>
                 </div>
               </CardContent>
             </Card>
 
-            {/* Navigation */}
-            <div className="flex items-center justify-between">
-              <Button
-                variant="outline"
-                onClick={handlePrevStep}
-                disabled={currentStepIndex === 0}
-              >
-                <ChevronLeft className="mr-2 w-4 h-4" />
-                Atgal
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <Button variant="outline" onClick={handlePrevStep} disabled={currentStepIndex === 0}>
+                <ChevronLeft className="mr-2 h-4 w-4" /> Atgal
               </Button>
 
-              <div className="flex items-center gap-3">
-                {!completedSteps.has(currentStepIndex) && (
-                  <Button onClick={handleStepComplete}>
-                    <CheckCircle2 className="mr-2 w-4 h-4" />
-                    Pažymėti kaip atliktą
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+                {!hasCurrentStepCompleted ? (
+                  <Button onClick={handleStepComplete} disabled={completeStepMutation.isPending}>
+                    <CheckCircle2 className="mr-2 h-4 w-4" />
+                    {completeStepMutation.isPending ? 'Žymima...' : 'Pažymėti kaip atliktą'}
                   </Button>
-                )}
-                
-                {currentStepIndex < steps.length - 1 && (
+                ) : null}
+
+                {currentStepIndex < steps.length - 1 ? (
                   <Button variant="outline" onClick={handleNextStep}>
                     Kitas žingsnis
-                    <ChevronRight className="ml-2 w-4 h-4" />
+                    <ChevronRight className="ml-2 h-4 w-4" />
                   </Button>
-                )}
+                ) : null}
               </div>
             </div>
           </div>
@@ -227,3 +331,4 @@ export default function TaskRun() {
     </MainLayout>
   );
 }
+


### PR DESCRIPTION
## Summary
- load assignments, hive, task, and completion data from the API in the tasks list and drive filtering off backend statuses
- add a reusable assignment status badge plus a dedicated task detail view that fetches assignment details
- refactor the task run experience to query assignment details and record step completion via backend mutations

## Testing
- npm run lint *(fails: existing lint errors in api service files and shared UI components)*
- npx eslint src/pages/Tasks.tsx src/pages/TaskRun.tsx src/pages/TaskDetail.tsx src/components/AssignmentStatusBadge.tsx src/lib/assignmentStatus.ts


------
https://chatgpt.com/codex/tasks/task_e_68e23a12af7c833387e7759f87536edf