### PR TITLE
Align frontend types with API responses

### DIFF
--- a/src/components/AssignmentStatusBadge.tsx
+++ b/src/components/AssignmentStatusBadge.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import type { BadgeProps } from '@/components/ui/badge';
-import type { AssignmentStatus } from '@/lib/api';
+import type { AssignmentStatus } from '@/lib/types';
 import {
   type AssignmentUiStatus,
   assignmentStatusLabels,

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
-import api, { AuthenticatedUser, HttpError, clearCredentials, setToken, type UserRole } from '@/lib/api';
+import api, { HttpError, clearCredentials, setToken } from '@/lib/api';
+import type { AuthenticatedUser, UserRole } from '@/lib/types';
+import { mapUserFromApi } from '@/lib/types';
 
 export type User = AuthenticatedUser & {
   phone?: string | null;
@@ -102,7 +104,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const bootstrap = async () => {
       try {
         const profile = await api.auth.me();
-        const normalizedUser = normalizeUser(profile);
+        const normalizedUser = normalizeUser(mapUserFromApi(profile));
         if (normalizedUser) {
           setUser(normalizedUser);
           persistUser(normalizedUser);
@@ -136,7 +138,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setToken(result.accessToken, result.refreshToken);
 
       const profile = await api.auth.me();
-      const normalizedUser = normalizeUser(profile);
+      const normalizedUser = normalizeUser(mapUserFromApi(profile));
       if (normalizedUser) {
         setUser(normalizedUser);
         persistUser(normalizedUser);
@@ -173,7 +175,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       setToken(result.accessToken, result.refreshToken);
 
       const profile = await api.auth.me();
-      const normalizedUser = normalizeUser(profile);
+      const normalizedUser = normalizeUser(mapUserFromApi(profile));
       if (normalizedUser) {
         setUser(normalizedUser);
         persistUser(normalizedUser);

--- a/src/lib/assignmentStatus.ts
+++ b/src/lib/assignmentStatus.ts
@@ -1,4 +1,4 @@
-import type { AssignmentStatus } from '@/lib/api';
+import type { AssignmentStatus } from '@/lib/types';
 
 export type AssignmentUiStatus = AssignmentStatus | 'overdue';
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,116 @@
+import type {
+  AssignmentDetails as ApiAssignmentDetails,
+  AssignmentResponse as ApiAssignmentResponse,
+  AssignmentStatus as ApiAssignmentStatus,
+  AuthenticatedUser as ApiAuthenticatedUser,
+  CreateAssignmentPayload,
+  CreateHivePayload,
+  CreateTaskPayload,
+  CreateTaskStepPayload,
+  HiveResponse as ApiHiveResponse,
+  HiveStatus as ApiHiveStatus,
+  HiveSummary as ApiHiveSummary,
+  LoginPayload,
+  NotificationResponse as ApiNotificationResponse,
+  RegisterPayload,
+  StepProgressResponse as ApiStepProgressResponse,
+  TaskFrequency as ApiTaskFrequency,
+  TaskResponse as ApiTaskResponse,
+  TaskStepResponse as ApiTaskStepResponse,
+  TaskWithStepsResponse as ApiTaskWithStepsResponse,
+  UpdateAssignmentPayload,
+  UpdateHivePayload,
+  UpdateTaskPayload,
+  UpdateTaskStepPayload,
+  UpdateUserPayload,
+  UserRole as ApiUserRole,
+} from './api';
+
+export type {
+  CreateAssignmentPayload,
+  CreateHivePayload,
+  CreateTaskPayload,
+  CreateTaskStepPayload,
+  LoginPayload,
+  RegisterPayload,
+  UpdateAssignmentPayload,
+  UpdateHivePayload,
+  UpdateTaskPayload,
+  UpdateTaskStepPayload,
+  UpdateUserPayload,
+} from './api';
+
+export type AuthenticatedUser = ApiAuthenticatedUser;
+export type Assignment = ApiAssignmentResponse;
+export type AssignmentDetails = ApiAssignmentDetails;
+export type AssignmentStatus = ApiAssignmentStatus;
+export type Hive = ApiHiveResponse;
+export type HiveStatus = ApiHiveStatus;
+export type Task = ApiTaskResponse;
+export type TaskWithSteps = ApiTaskWithStepsResponse;
+export type TaskStep = ApiTaskStepResponse;
+export type StepProgress = ApiStepProgressResponse;
+export type Notification = ApiNotificationResponse;
+export type HiveSummary = ApiHiveSummary;
+export type TaskFrequency = ApiTaskFrequency;
+export type UserRole = ApiUserRole;
+
+export interface User extends ApiAuthenticatedUser {
+  phone?: string | null;
+  address?: string | null;
+  createdAt?: string | null;
+}
+
+const mapOptionalString = (value?: string | null) => (value === undefined || value === null ? null : value);
+
+export const mapHiveFromApi = (hive: ApiHiveResponse): Hive => ({
+  ...hive,
+  location: hive.location ?? null,
+  queenYear: hive.queenYear ?? null,
+});
+
+export const mapTaskStepFromApi = (step: ApiTaskStepResponse): TaskStep => ({
+  ...step,
+  contentText: step.contentText ?? null,
+  mediaUrl: step.mediaUrl ?? null,
+});
+
+export const mapTaskFromApi = (task: ApiTaskResponse): Task => ({
+  ...task,
+  seasonMonths: Array.isArray(task.seasonMonths) ? [...task.seasonMonths] : [],
+});
+
+export const mapTaskWithStepsFromApi = (task: ApiTaskWithStepsResponse): TaskWithSteps => ({
+  ...mapTaskFromApi(task),
+  steps: task.steps.map(mapTaskStepFromApi),
+});
+
+export const mapAssignmentFromApi = (assignment: ApiAssignmentResponse): Assignment => ({
+  ...assignment,
+});
+
+export const mapStepProgressFromApi = (progress: ApiStepProgressResponse): StepProgress => ({
+  ...progress,
+  notes: mapOptionalString(progress.notes),
+  evidenceUrl: mapOptionalString(progress.evidenceUrl),
+});
+
+export const mapAssignmentDetailsFromApi = (details: ApiAssignmentDetails): AssignmentDetails => ({
+  assignment: mapAssignmentFromApi(details.assignment),
+  task: mapTaskWithStepsFromApi(details.task),
+  progress: (details.progress ?? []).map(mapStepProgressFromApi),
+  completion: details.completion ?? 0,
+});
+
+export const mapNotificationFromApi = (notification: ApiNotificationResponse): Notification => ({
+  ...notification,
+  title: mapOptionalString(notification.title),
+  message: mapOptionalString(notification.message),
+  scheduledAt: mapOptionalString(notification.scheduledAt),
+  sentAt: mapOptionalString(notification.sentAt),
+  readAt: mapOptionalString(notification.readAt),
+});
+
+export const mapUserFromApi = (user: ApiAuthenticatedUser): User => ({
+  ...user,
+});

--- a/src/pages/TaskDetail.tsx
+++ b/src/pages/TaskDetail.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { AssignmentStatusBadge } from '@/components/AssignmentStatusBadge';
 import api from '@/lib/api';
+import { mapAssignmentDetailsFromApi, type AssignmentDetails } from '@/lib/types';
 import { Calendar, ChevronLeft, ClipboardList, Loader2 } from 'lucide-react';
 
 const formatDate = (dateStr?: string | null) => {
@@ -26,9 +27,9 @@ export default function TaskDetail() {
     isLoading,
     isError,
     error,
-  } = useQuery({
+  } = useQuery<AssignmentDetails, Error>({
     queryKey: ['assignments', id, 'details'],
-    queryFn: () => api.assignments.details(id ?? ''),
+    queryFn: () => api.assignments.details(id ?? '').then(mapAssignmentDetailsFromApi),
     enabled: Boolean(id),
   });
 

--- a/src/pages/admin/Steps.tsx
+++ b/src/pages/admin/Steps.tsx
@@ -8,7 +8,8 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import api, { type TaskStepResponse } from '@/lib/api';
+import api from '@/lib/api';
+import { mapTaskFromApi, mapTaskStepFromApi, type Task, type TaskStep } from '@/lib/types';
 import { Plus, Search, Edit, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -18,9 +19,12 @@ export default function AdminSteps() {
   const [selectedTaskId, setSelectedTaskId] = useState<string>('');
   const queryClient = useQueryClient();
 
-  const { data: tasks = [] } = useQuery({
+  const { data: tasks = [] } = useQuery<Task[]>({
     queryKey: ['tasks', 'for-steps'],
-    queryFn: api.tasks.list,
+    queryFn: async () => {
+      const response = await api.tasks.list();
+      return response.map(mapTaskFromApi);
+    },
   });
 
   useEffect(() => {
@@ -29,9 +33,9 @@ export default function AdminSteps() {
     }
   }, [tasks, selectedTaskId]);
 
-  const { data: steps = [], isLoading, isError } = useQuery({
+  const { data: steps = [], isLoading, isError } = useQuery<TaskStep[]>({
     queryKey: ['tasks', selectedTaskId, 'steps'],
-    queryFn: () => api.tasks.getSteps(selectedTaskId!),
+    queryFn: () => api.tasks.getSteps(selectedTaskId!).then((response) => response.map(mapTaskStepFromApi)),
     enabled: !!selectedTaskId,
   });
 
@@ -207,7 +211,7 @@ function StepCard({
   onDelete,
   disableActions,
 }: {
-  step: TaskStepResponse;
+  step: TaskStep;
   onDelete: () => void;
   disableActions: boolean;
 }) {

--- a/src/pages/admin/Tasks.tsx
+++ b/src/pages/admin/Tasks.tsx
@@ -6,16 +6,20 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import api, { type TaskResponse } from '@/lib/api';
+import api from '@/lib/api';
+import { mapTaskFromApi, type Task } from '@/lib/types';
 import { Plus, Search, Edit, Archive } from 'lucide-react';
 
 export default function AdminTasks() {
   const [searchQuery, setSearchQuery] = useState('');
   const [categoryFilter, setCategoryFilter] = useState<string>('all');
 
-  const { data: tasks = [], isLoading, isError } = useQuery({
+  const { data: tasks = [], isLoading, isError } = useQuery<Task[]>({
     queryKey: ['tasks', 'admin', 'overview'],
-    queryFn: api.tasks.list,
+    queryFn: async () => {
+      const response = await api.tasks.list();
+      return response.map(mapTaskFromApi);
+    },
   });
 
   const filteredTasks = useMemo(() => {
@@ -31,8 +35,8 @@ export default function AdminTasks() {
     });
   }, [tasks, searchQuery, categoryFilter]);
 
-  const getFrequencyLabel = (frequency: TaskResponse['frequency']) => {
-    const labels: Record<TaskResponse['frequency'], string> = {
+  const getFrequencyLabel = (frequency: Task['frequency']) => {
+    const labels: Record<Task['frequency'], string> = {
       once: 'Vienkartinė',
       weekly: 'Kas savaitę',
       monthly: 'Kas mėnesį',

--- a/src/pages/admin/Templates.tsx
+++ b/src/pages/admin/Templates.tsx
@@ -5,15 +5,19 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
-import api, { type TaskResponse } from '@/lib/api';
+import api from '@/lib/api';
+import { mapTaskFromApi, type Task } from '@/lib/types';
 import { Plus, Search, Edit } from 'lucide-react';
 
 export default function AdminTemplates() {
   const [searchQuery, setSearchQuery] = useState('');
 
-  const { data: tasks = [], isLoading, isError } = useQuery({
+  const { data: tasks = [], isLoading, isError } = useQuery<Task[]>({
     queryKey: ['tasks', 'admin', 'list'],
-    queryFn: api.tasks.list,
+    queryFn: async () => {
+      const response = await api.tasks.list();
+      return response.map(mapTaskFromApi);
+    },
   });
 
   const filteredTasks = useMemo(() => {
@@ -75,7 +79,7 @@ export default function AdminTemplates() {
   );
 }
 
-function TaskCard({ task }: { task: TaskResponse }) {
+function TaskCard({ task }: { task: Task }) {
   return (
     <Card className="shadow-sm">
       <CardContent className="p-6">

--- a/src/pages/admin/Users.tsx
+++ b/src/pages/admin/Users.tsx
@@ -23,7 +23,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import api, { type UserRole } from '@/lib/api';
+import api from '@/lib/api';
+import type { UserRole } from '@/lib/types';
 import { Plus, Search, Edit, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 


### PR DESCRIPTION
## Summary
- add a shared lib/types module that mirrors API enums and normalizes response fields
- update dashboards, hive/task flows, and status badges to use the new enums and mapping helpers

## Testing
- npm run build
- npm run lint *(fails: existing API package lint errors about explicit any and react-refresh warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68e2434ac6808333b04164223e4a29b6